### PR TITLE
Make mp4 animations along with JSAnimations and add to _PlotIndex.html

### DIFF
--- a/src/python/visclaw/gaugetools.py
+++ b/src/python/visclaw/gaugetools.py
@@ -212,8 +212,11 @@ def plotgauge(gaugeno, plotdata, verbose=False):
 
 
         if 'facecolor' not in plotfigure.kwargs:
-            # use Clawpack's default bg color (tan)
-            plotfigure.kwargs['facecolor'] = '#ffeebb'   
+            # Use white as default starting in v5.10.0
+            # To use old default Clawpack tan, in setplot.py set:
+            #     plotfigure.facecolor = \
+            #           clawpack.visclaw.colormaps.clawpack_tan
+            plotfigure.kwargs['facecolor'] = 'w'
 
         if plotfigure.figsize is not None:
             plotfigure.kwargs['figsize'] = plotfigure.figsize

--- a/src/python/visclaw/plotpages.py
+++ b/src/python/visclaw/plotpages.py
@@ -1837,11 +1837,13 @@ def massage_frames_data(plot_pages_data):
 
     allframesfile = {}
     moviefile = {}
+    moviefile_mp4 = {}
     for figno in fignos:
         if figno not in fignames:
             fignames[figno] = 'Solution'
         allframesfile[figno] = 'allframes_fig%s.html'  % figno
         moviefile[figno] = 'movie_fig%s.html'  % figno
+        moviefile_mp4[figno] = 'movie_fig%s.mp4'  % figno
 
     numframes = len(framenos)
     numfigs = len(fignos)
@@ -1885,6 +1887,7 @@ def massage_frames_data(plot_pages_data):
     ppd._allfigsfile = allfigsfile
     ppd._allframesfile = allframesfile
     ppd._moviefile = moviefile
+    ppd._moviefile_mp4 = moviefile_mp4
     return ppd
 
 
@@ -2166,6 +2169,7 @@ def plotclaw2html(plotdata):
     allfigsfile = plotdata._allfigsfile
     allframesfile = plotdata._allframesfile
     moviefile = plotdata._moviefile
+    moviefile_mp4 = plotdata._moviefile_mp4
 
     numframes = len(framenos)
     numfigs = len(fignos)
@@ -2236,6 +2240,12 @@ def plotclaw2html(plotdata):
         for figno in fignos:
             html.write('\n   <td><a href="%s">%s</a></td>' \
                            % (moviefile[figno],fignames[figno]))
+        html.write('</tr>\n')
+    if plotdata.ffmpeg_movie:
+        html.write('<p><tr><td><b>mp4 Movies:</b></td>')
+        for figno in fignos:
+            html.write('\n   <td><a href="%s">%s</a></td>' \
+                           % (moviefile_mp4[figno],fignames[figno]))
         html.write('</tr>\n')
     if plotdata.gif_movie:
         html.write('<p><tr><td><b>gif Movies:</b></td>')
@@ -3075,7 +3085,7 @@ def plotclaw_driver(plotdata, verbose=False, format='ascii'):
                             file_name_prefix='movie_',
                             png_prefix=png_prefix,
                             figsize=None,
-                            fignos=[figno], outputs=['html'], raw_html=raw_html)
+                            fignos=[figno], outputs=['html','mp4'], raw_html=raw_html)
 
             # Note: setting figsize=None above chooses figsize with aspect
             # ratio based on .png files read in, may fit better on page


### PR DESCRIPTION
Here's another way to make mp4 animations using what's already built into `plotpages.py` using `animation_tools.make_anim_outputs_from_plotdir()`, and adds it to the index.

Note this makes e.g. `movie_fig0.mp4` while the original code of @kbarnhart (still included) makes `moviefig0.mp4`, and her approach allows more easily passing other options to ffmpeg so that might be preferable.

See https://github.com/clawpack/visclaw/pull/302 for more discussion of this general approach.